### PR TITLE
Use Faster `NSTextStorage` Substring

### DIFF
--- a/Sources/TextStory/NSTextStorage+TextStoring.swift
+++ b/Sources/TextStory/NSTextStorage+TextStoring.swift
@@ -23,6 +23,6 @@ extension NSTextStorage: TextStoring {
             return nil
         }
 
-        return attributedSubstring(from: range).string
+        return (string as NSString).substring(with: range)
     }
 }


### PR DESCRIPTION
Updates `NSTextStorage`'s `TextStoring` conformance to use the much faster `NSString.substring` method instead of creating an attributed substring. This avoids any unnecessary attribute fixing, attribute allocation, etc.